### PR TITLE
sync with develop & resolve conflict

### DIFF
--- a/easybuild/easyconfigs/m/METIS/METIS-5.1.0-intel-2015b.eb
+++ b/easybuild/easyconfigs/m/METIS/METIS-5.1.0-intel-2015b.eb
@@ -1,0 +1,22 @@
+name = 'METIS'
+version = '5.1.0'
+
+homepage = 'http://glaros.dtc.umn.edu/gkhome/metis/metis/overview'
+description = """METIS is a set of serial programs for partitioning graphs, partitioning finite element meshes,
+and producing fill reducing orderings for sparse matrices. The algorithms implemented in METIS are based on the
+multilevel recursive-bisection, multilevel k-way, and multi-constraint partitioning schemes."""
+
+toolchain = {'name': 'intel', 'version': '2015b'}
+toolchainopts = {'optarch': True, 'pic': True}
+
+sources = [SOURCELOWER_TAR_GZ]
+source_urls = [
+    'http://glaros.dtc.umn.edu/gkhome/fetch/sw/metis',
+    'http://glaros.dtc.umn.edu/gkhome/fetch/sw/metis/OLD',
+]
+
+patches = ['METIS_IDXTYPEWIDTH.patch']
+
+builddependencies = [('CMake', '3.3.2')]
+
+moduleclass = 'math'

--- a/easybuild/easyconfigs/n/numpy/numpy-1.9.2-intel-2015b-Python-2.7.10.eb
+++ b/easybuild/easyconfigs/n/numpy/numpy-1.9.2-intel-2015b-Python-2.7.10.eb
@@ -1,0 +1,27 @@
+name = 'numpy'
+version = '1.9.2'
+
+homepage = 'http://www.numpy.org'
+description = """NumPy is the fundamental package for scientific computing with Python. It contains among other things:
+ a powerful N-dimensional array object, sophisticated (broadcasting) functions, tools for integrating C/C++ and Fortran
+ code, useful linear algebra, Fourier transform, and random number capabilities. Besides its obvious scientific uses,
+ NumPy can also be used as an efficient multi-dimensional container of generic data. Arbitrary data-types can be 
+ defined. This allows NumPy to seamlessly and speedily integrate with a wide variety of databases."""
+
+toolchain = {'name': 'intel', 'version': '2015b'}
+
+source_urls = [SOURCEFORGE_SOURCE]
+sources = [SOURCE_TAR_GZ]
+
+patches = ['numpy-1.8.0-mkl.patch']
+
+python = 'Python'
+pyver = '2.7.10'
+versionsuffix = '-%s-%s' % (python, pyver)
+
+dependencies = [
+    (python, pyver),
+    ('SuiteSparse', '4.4.5', '-ParMETIS-4.0.3'),
+]
+
+moduleclass = 'math'

--- a/easybuild/easyconfigs/p/PCRE/PCRE-8.37-intel-2015b.eb
+++ b/easybuild/easyconfigs/p/PCRE/PCRE-8.37-intel-2015b.eb
@@ -1,0 +1,20 @@
+easyblock = 'ConfigureMake'
+
+name = 'PCRE'
+version = '8.37'
+
+homepage = 'http://www.pcre.org/'
+description = """
+ The PCRE library is a set of functions that implement regular expression pattern matching using the same syntax
+ and semantics as Perl 5.
+"""
+
+toolchain = {'name': 'intel', 'version': '2015b'}
+toolchainopts = {'optarch': True, 'pic': True}
+
+configopts = "--with-pic --disable-cpp"
+
+source_urls = [SOURCEFORGE_SOURCE]
+sources = [SOURCELOWER_TAR_GZ]
+
+moduleclass = 'devel'

--- a/easybuild/easyconfigs/p/ParMETIS/ParMETIS-4.0.3-intel-2015b.eb
+++ b/easybuild/easyconfigs/p/ParMETIS/ParMETIS-4.0.3-intel-2015b.eb
@@ -1,0 +1,22 @@
+name = 'ParMETIS'
+version = '4.0.3'
+
+homepage = 'http://glaros.dtc.umn.edu/gkhome/metis/parmetis/overview'
+description = """ParMETIS is an MPI-based parallel library that implements a variety of algorithms for partitioning unstructured graphs,
+ meshes, and for computing fill-reducing orderings of sparse matrices. ParMETIS extends the functionality provided by METIS and includes
+ routines that are especially suited for parallel AMR computations and large scale numerical simulations. The algorithms implemented in
+ ParMETIS are based on the parallel multilevel k-way graph-partitioning, adaptive repartitioning, and parallel multi-constrained partitioning
+ schemes."""
+
+toolchain = {'name': 'intel', 'version': '2015b'}
+toolchainopts = {'optarch': True, 'usempi': True, 'pic': True}
+
+source_urls = [
+    'http://glaros.dtc.umn.edu/gkhome/fetch/sw/parmetis',
+    'http://glaros.dtc.umn.edu/gkhome/fetch/sw/parmetis/OLD',
+]
+sources = [SOURCELOWER_TAR_GZ]
+
+builddependencies = [('CMake', '3.3.2', '', ('GNU', '4.9.3-2.25'))]
+
+moduleclass = 'math'

--- a/easybuild/easyconfigs/s/SWIG/SWIG-3.0.7-intel-2015b-Python-2.7.10.eb
+++ b/easybuild/easyconfigs/s/SWIG/SWIG-3.0.7-intel-2015b-Python-2.7.10.eb
@@ -1,0 +1,23 @@
+name = 'SWIG'
+version = '3.0.7'
+
+homepage = 'http://www.swig.org/'
+description = """SWIG is a software development tool that connects programs written in C and C++ with
+ a variety of high-level programming languages."""
+
+toolchain = {'name': 'intel', 'version': '2015b'}
+toolchainopts = {'pic': True, 'opt': True, 'optarch': True}
+
+source_urls = [SOURCEFORGE_SOURCE]
+sources = [SOURCELOWER_TAR_GZ]
+
+python = "Python"
+pythonversion = '2.7.10'
+versionsuffix = '-%s-%s' % (python, pythonversion)
+
+dependencies = [
+    (python, pythonversion),
+    ('PCRE', '8.37'),
+]
+
+moduleclass = 'devel'

--- a/easybuild/easyconfigs/s/SuiteSparse/AMD_GNUMakefile-4.4.5.patch
+++ b/easybuild/easyconfigs/s/SuiteSparse/AMD_GNUMakefile-4.4.5.patch
@@ -1,0 +1,42 @@
+--- SuiteSparse/AMD/Lib/GNUmakefile.org	2014-03-21 20:22:00.000000000 +0100
++++ SuiteSparse/AMD/Lib/GNUmakefile	2015-10-12 16:30:32.153222621 +0200
+@@ -2,7 +2,7 @@
+ # AMD Makefile for compiling on Unix systems (for GNU make only)
+ #-------------------------------------------------------------------------------
+ 
+-default: libamd.a
++default: libamd.a libamd.so
+ 
+ include ../../SuiteSparse_config/SuiteSparse_config.mk
+ 
+@@ -30,6 +30,9 @@
+ # compile each int and long routine (with no real/complex version)
+ #-------------------------------------------------------------------------------
+ 
++amd_global.o: ../Source/amd_global.c $(INC)
++	$(C) -c $< -o $@
++
+ amd_i_%.o: ../Source/amd_%.c $(INC)
+ 	$(C) -DDINT -c $< -o $@
+ 
+@@ -40,10 +43,13 @@
+ # Create the libamd.a library (C versions only)
+ #-------------------------------------------------------------------------------
+ 
+-libamd.a: $(AMDI) $(AMDL)
++libamd.a: amd_global.o $(AMDI) $(AMDL)
+ 	$(ARCHIVE) libamd.a $^
+ 	- $(RANLIB) libamd.a
+ 
++libamd.so: amd_global.o $(AMDI) $(AMDL)
++	$(CC) -shared $^ -lm -Wl,-soname -Wl,$@ -o libamd.so
++
+ #-------------------------------------------------------------------------------
+ # compile the Fortran versions and the libamdf77.a library
+ #-------------------------------------------------------------------------------
+@@ -72,4 +78,4 @@
+ purge: distclean
+ 
+ distclean: clean
+-	- $(RM) libamd.a libamdf77.a
++	- $(RM) libamd.a libamdf77.a libamd.so

--- a/easybuild/easyconfigs/s/SuiteSparse/SuiteSparse-4.4.5-intel-2015b-ParMETIS-4.0.3.eb
+++ b/easybuild/easyconfigs/s/SuiteSparse/SuiteSparse-4.4.5-intel-2015b-ParMETIS-4.0.3.eb
@@ -1,0 +1,25 @@
+name = 'SuiteSparse'
+version = '4.4.5'
+
+homepage = 'http://www.cise.ufl.edu/research/sparse/SuiteSparse/'
+description = """SuiteSparse is a collection of libraries manipulate sparse matrices."""
+
+toolchain = {'name': 'intel', 'version': '2015b'}
+toolchainopts = {'opt': True, 'unroll': True, 'pic': True}
+
+source_urls = ['http://faculty.cse.tamu.edu/davis/SuiteSparse/']
+sources = [SOURCE_TAR_GZ]
+
+patches = [
+           'AMD_GNUMakefile-4.4.5.patch', 
+           'UMFPACK_GNUMakefile-4.4.5.patch',
+          ]
+
+parmetis = 'ParMETIS'
+parmetis_ver = '4.0.3'
+versionsuffix = '-%s-%s' % (parmetis, parmetis_ver)
+dependencies = [(parmetis, parmetis_ver)]
+
+maxparallel = 1
+
+moduleclass = 'numlib'

--- a/easybuild/easyconfigs/s/SuiteSparse/UMFPACK_GNUMakefile-4.4.5.patch
+++ b/easybuild/easyconfigs/s/SuiteSparse/UMFPACK_GNUMakefile-4.4.5.patch
@@ -22,7 +22,7 @@
  
 +# I = -I../Include -I../Source -I../../AMD/Include -I../../SuiteSparse_config \
 +#     -I../../CCOLAMD/Include -I../../CAMD/Include -I../../CHOLMOD/Include \
-+#     -I../../metis-4.0/Lib -I../../COLAMD/Include    
++#     -I$(EBROOTPARMETIS)/include -I../../COLAMD/Include    
 +
  C = $(CC) $(CF) $(UMFPACK_CONFIG) $(I)
  

--- a/easybuild/easyconfigs/s/SuiteSparse/UMFPACK_GNUMakefile-4.4.5.patch
+++ b/easybuild/easyconfigs/s/SuiteSparse/UMFPACK_GNUMakefile-4.4.5.patch
@@ -1,0 +1,57 @@
+--- SuiteSparse/UMFPACK/Lib/GNUmakefile.org	2014-03-21 20:16:16.000000000 +0100
++++ SuiteSparse/UMFPACK/Lib/GNUmakefile	2015-10-12 16:34:54.286168878 +0200
+@@ -2,18 +2,22 @@
+ # UMFPACK Makefile for compiling on Unix systems (for GNU Make)
+ #-------------------------------------------------------------------------------
+ 
+-default: libumfpack.a
++default: libumfpack.a libumfpack.so
+ 
+ include ../../SuiteSparse_config/SuiteSparse_config.mk
+ 
+ # UMFPACK can use CHOLMOD by default as an ordering option
+ ifneq (,$(findstring -DNCHOLMOD, $(UMFPACK_CONFIG)))
+-    I = -I../Include -I../Source -I../../AMD/Include -I../../SuiteSparse_config
++   I = -I../Include -I../Source -I../../AMD/Include -I../../SuiteSparse_config
+ else
+-    I = -I../Include -I../Source -I../../AMD/Include \
+-        -I../../SuiteSparse_config -I../../CHOLMOD/Include
++   I = -I../Include -I../Source -I../../AMD/Include \
++       -I../../SuiteSparse_config -I../../CHOLMOD/Include
+ endif
+ 
++# I = -I../Include -I../Source -I../../AMD/Include -I../../SuiteSparse_config \
++#     -I../../CCOLAMD/Include -I../../CAMD/Include -I../../CHOLMOD/Include \
++#     -I../../metis-4.0/Lib -I../../COLAMD/Include    
++
+ C = $(CC) $(CF) $(UMFPACK_CONFIG) $(I)
+ 
+ #-------------------------------------------------------------------------------
+@@ -69,7 +73,7 @@
+ 
+ # user-callable, only one version for int/SuiteSparse_long,
+ # real/complex, *.[ch] files:
+-GENERIC = umfpack_timer umfpack_tictoc
++GENERIC = umfpack_timer umfpack_tictoc umfpack_global
+ 
+ #-------------------------------------------------------------------------------
+ # include files:
+@@ -257,8 +261,8 @@
+ 	$(ARCHIVE)  libumfpack.a $^
+ 	- $(RANLIB) libumfpack.a
+ 
+-so: $(II) $(LL) $(GN) $(DI) $(DL) $(ZI) $(ZL)
+-	gcc -shared -Wl,-soname,libumfpack.so -o libumfpack.so $^
++libumfpack.so: $(II) $(LL) $(GN) $(DI) $(DL) $(ZI) $(ZL)
++	$(CC) -shared $^ -lm -L ../../CHOLMOD/Lib -lcholmod -L ../../CAMD/Lib -lcamd -L ../../COLAMD/Lib -lcolamd $(EBROOTPARMETIS)/lib/libparmetis.a $(EBROOTPARMETIS)/lib/libmetis.a -L../../CCOLAMD/Lib -lccolamd -L ../../SuiteSparse_config -lsuitesparseconfig ../../AMD/Lib/libamd.so -Wl,-soname -Wl,$@ -o libumfpack.so
+ 
+ #-------------------------------------------------------------------------------
+ # Remove all but the files in the original distribution
+@@ -266,6 +270,7 @@
+ 
+ purge: clean
+ 	- $(RM) libumfpack.a
++	- $(RM) libumfpack.so
+ 
+ clean:
+ 	- $(RM) $(CLEAN)

--- a/easybuild/easyconfigs/s/scikit-umfpack/scikit-umfpack-0.2.1-intel-2015b-Python-2.7.10.eb
+++ b/easybuild/easyconfigs/s/scikit-umfpack/scikit-umfpack-0.2.1-intel-2015b-Python-2.7.10.eb
@@ -1,4 +1,3 @@
-# Built with EasyBuild version 2.3.0 on 2015-10-16_10-29-33
 easyblock = 'PythonPackage'
 
 name = 'scikit-umfpack'
@@ -18,7 +17,7 @@ pyver = '2.7.10'
 versionsuffix = "-%s-%s" % (python, pyver)
 dependencies = [
     (python, pyver),
-    ('scipy', '0.16.0', versionsuffix),
+    ('scipy', '0.15.1', versionsuffix),
     ('SuiteSparse', '4.4.5', '-ParMETIS-4.0.3'),
 ]
 
@@ -35,28 +34,3 @@ sanity_check_paths = {
 }
 
 moduleclass = 'math'
-
-# Build statistics
-buildstats = [{
-    "easybuild-framework_version": "2.3.0",
-    "easybuild-easyblocks_version": "2.3.0",
-    "timestamp": 1444984173,
-    "build_time": 4.99,
-    "install_size": 15332591,
-    "command_line": ['--buildpath=/dev/shm', '--force', '--installpath-modules=/apps/antwerpen/modules/hopper/2015b', '--installpath-software=/apps/antwerpen/ivybridge/sl6', '--repositorypath=/apps/antwerpen/easybuild/repo', '--robot=/apps/antwerpen/easybuild/github/easybuild-easyconfigs/easybuild/easyconfigs:/apps/antwerpen/ivybridge/sl6/EasyBuild/2.3.0/lib/python2.6/site-packages/easybuild_easyconfigs-2.3.0-py2.6.egg/easybuild/easyconfigs', '--robot-paths=/apps/antwerpen/easybuild/github/easybuild-easyconfigs/easybuild/easyconfigs:', '--sourcepath=/apps/antwerpen/sources', 'scikit-umfpack-0.2.1-intel-2015b-Python-2.7.10.eb'],
-    "modules_tool": ('EnvironmentModulesC', '/usr/bin/modulecmd', '3.2.10'),
-    "core_count": 20,
-    "cpu_model": "Intel(R) Xeon(R) CPU E5-2680 v2 @ 2.80GHz",
-    "cpu_speed": 2793.089,
-    "cpu_vendor": "Intel",
-    "gcc_version": "Ingebouwde specs worden gebruikt.; COLLECT_GCC=gcc; COLLECT_LTO_WRAPPER=/apps/antwerpen/ivybridge/sl6/GCC/4.9.3-binutils-2.25/libexec/gcc/x86_64-unknown-linux-gnu/4.9.3/lto-wrapper; Target: x86_64-unknown-linux-gnu; Configured with: ../configure --enable-languages=c,c++,fortran --enable-lto --enable-checking=release --disable-multilib --enable-shared=yes --enable-static=yes --enable-threads=posix --enable-gold=default --enable-plugins --enable-ld --with-plugin-ld=ld.gold --enable-bootstrap --prefix=/apps/antwerpen/ivybridge/sl6/GCC/4.9.3-binutils-2.25 --with-local-prefix=/apps/antwerpen/ivybridge/sl6/GCC/4.9.3-binutils-2.25; Thread model: posix; gcc versie 4.9.3 (GCC) ; ",
-    "glibc_version": "2.12",
-    "hostname": "ln01.hopper.antwerpen.vsc",
-    "os_name": "SL",
-    "os_type": "Linux",
-    "os_version": "6.7",
-    "platform_name": "x86_64-unknown-linux",
-    "python_version": "2.6.6 (r266:84292, Jul 22 2015, 16:47:47) ; [GCC 4.4.7 20120313 (Red Hat 4.4.7-16)]",
-    "system_gcc_path": "/apps/antwerpen/ivybridge/sl6/GCC/4.9.3-binutils-2.25/bin/gcc",
-    "system_python_path": "/apps/antwerpen/ivybridge/sl6/Python/2.7.10-intel-2015b/bin/python",
-}]

--- a/easybuild/easyconfigs/s/scikit-umfpack/scikit-umfpack-0.2.1-intel-2015b-Python-2.7.10.eb
+++ b/easybuild/easyconfigs/s/scikit-umfpack/scikit-umfpack-0.2.1-intel-2015b-Python-2.7.10.eb
@@ -1,0 +1,62 @@
+# Built with EasyBuild version 2.3.0 on 2015-10-16_10-29-33
+easyblock = 'PythonPackage'
+
+name = 'scikit-umfpack'
+version = '0.2.1'
+
+homepage = 'http://rc.github.io/scikit-umfpack/'
+description = """scikit-umfpack provides a wrapper of UMFPACK sparse direct solver to SciPy."""
+
+toolchain = {'name': 'intel', 'version': '2015b'}
+
+source_urls = [PYPI_SOURCE]
+sources = [SOURCE_TAR_GZ]
+
+python = 'Python'
+pyver = '2.7.10'
+
+versionsuffix = "-%s-%s" % (python, pyver)
+dependencies = [
+    (python, pyver),
+    ('scipy', '0.16.0', versionsuffix),
+    ('SuiteSparse', '4.4.5', '-ParMETIS-4.0.3'),
+]
+
+builddependencies = [
+    ('SWIG', '3.0.7', versionsuffix),
+] 
+
+options = {'modulename': 'scikits'}
+
+pyshortver = '.'.join(pyver.split('.')[:-1])
+sanity_check_paths = {
+    'files': [],
+    'dirs': ['lib/python%s/site-packages/scikits/umfpack' % pyshortver],
+}
+
+moduleclass = 'math'
+
+# Build statistics
+buildstats = [{
+    "easybuild-framework_version": "2.3.0",
+    "easybuild-easyblocks_version": "2.3.0",
+    "timestamp": 1444984173,
+    "build_time": 4.99,
+    "install_size": 15332591,
+    "command_line": ['--buildpath=/dev/shm', '--force', '--installpath-modules=/apps/antwerpen/modules/hopper/2015b', '--installpath-software=/apps/antwerpen/ivybridge/sl6', '--repositorypath=/apps/antwerpen/easybuild/repo', '--robot=/apps/antwerpen/easybuild/github/easybuild-easyconfigs/easybuild/easyconfigs:/apps/antwerpen/ivybridge/sl6/EasyBuild/2.3.0/lib/python2.6/site-packages/easybuild_easyconfigs-2.3.0-py2.6.egg/easybuild/easyconfigs', '--robot-paths=/apps/antwerpen/easybuild/github/easybuild-easyconfigs/easybuild/easyconfigs:', '--sourcepath=/apps/antwerpen/sources', 'scikit-umfpack-0.2.1-intel-2015b-Python-2.7.10.eb'],
+    "modules_tool": ('EnvironmentModulesC', '/usr/bin/modulecmd', '3.2.10'),
+    "core_count": 20,
+    "cpu_model": "Intel(R) Xeon(R) CPU E5-2680 v2 @ 2.80GHz",
+    "cpu_speed": 2793.089,
+    "cpu_vendor": "Intel",
+    "gcc_version": "Ingebouwde specs worden gebruikt.; COLLECT_GCC=gcc; COLLECT_LTO_WRAPPER=/apps/antwerpen/ivybridge/sl6/GCC/4.9.3-binutils-2.25/libexec/gcc/x86_64-unknown-linux-gnu/4.9.3/lto-wrapper; Target: x86_64-unknown-linux-gnu; Configured with: ../configure --enable-languages=c,c++,fortran --enable-lto --enable-checking=release --disable-multilib --enable-shared=yes --enable-static=yes --enable-threads=posix --enable-gold=default --enable-plugins --enable-ld --with-plugin-ld=ld.gold --enable-bootstrap --prefix=/apps/antwerpen/ivybridge/sl6/GCC/4.9.3-binutils-2.25 --with-local-prefix=/apps/antwerpen/ivybridge/sl6/GCC/4.9.3-binutils-2.25; Thread model: posix; gcc versie 4.9.3 (GCC) ; ",
+    "glibc_version": "2.12",
+    "hostname": "ln01.hopper.antwerpen.vsc",
+    "os_name": "SL",
+    "os_type": "Linux",
+    "os_version": "6.7",
+    "platform_name": "x86_64-unknown-linux",
+    "python_version": "2.6.6 (r266:84292, Jul 22 2015, 16:47:47) ; [GCC 4.4.7 20120313 (Red Hat 4.4.7-16)]",
+    "system_gcc_path": "/apps/antwerpen/ivybridge/sl6/GCC/4.9.3-binutils-2.25/bin/gcc",
+    "system_python_path": "/apps/antwerpen/ivybridge/sl6/Python/2.7.10-intel-2015b/bin/python",
+}]

--- a/easybuild/easyconfigs/s/scipy/scipy-0.15.1-intel-2015b-Python-2.7.10.eb
+++ b/easybuild/easyconfigs/s/scipy/scipy-0.15.1-intel-2015b-Python-2.7.10.eb
@@ -1,0 +1,19 @@
+name = 'scipy'
+version = '0.15.1'
+versionsuffix = '-Python-2.7.10'
+
+homepage = 'http://www.scipy.org'
+description = """SciPy is a collection of mathematical algorithms and convenience
+ functions built on the Numpy extension for Python."""
+
+toolchain = {'name': 'intel', 'version': '2015b'}
+toolchainopts = {'pic': True}
+
+source_urls = [('http://sourceforge.net/projects/scipy/files/scipy/%(version)s', 'download')]
+sources = [SOURCE_TAR_GZ]
+
+dependencies = [
+    ('numpy', '1.9.2', versionsuffix),
+]
+
+moduleclass = 'math'


### PR DESCRIPTION
for https://github.com/hpcugent/easybuild-easyconfigs/pull/2061

@sbecuwe: this sync up the branch corresponding with https://github.com/hpcugent/easybuild-easyconfigs/pull/2061 with current develop; this is required to fix the conflict on the METIS-5.1.0-intel-2015b.eb easyconfig, since that is already included in the `develop` branch with this added (yours doesn't have this) to also enable building shared libraries

```
configopts = ['', 'shared=1']
```
